### PR TITLE
changed index naming convention so that they start with logstash

### DIFF
--- a/src/cmd/vossibility-collector/storage/repository.go
+++ b/src/cmd/vossibility-collector/storage/repository.go
@@ -155,7 +155,7 @@ func (r *Repository) StateIndexForTimestamp(timestamp time.Time) string {
 // this repository's snapshot data (such as the latest state of each pull
 // request and issue).
 func (r *Repository) SnapshotIndex() string {
-	return fmt.Sprintf("%ssnapshot", r.IndexPrefix())
+	return fmt.Sprintf("logstash-%ssnapshot", r.IndexPrefix())
 }
 
 // IsSubscribed returns whether we should subscribe for a particular GitHub


### PR DESCRIPTION
```
by default logstash adds .raw version of each string (not_analyzed) if it sees the index name starts with logstash
this way we can do full text search and also have meaninful graphs were the text is not tokenized
```
